### PR TITLE
Remove ANSI characters from status line

### DIFF
--- a/Source/Worker.swift
+++ b/Source/Worker.swift
@@ -174,7 +174,7 @@ class Worker: ObservableObject {
             let lines = string.split(whereSeparator: \.isNewline)
             if let line = lines.filter({ !$0.isEmpty }).last {
                 let stringLine = String(line)
-                if let pattern = try? NSRegularExpression(pattern: "\\[(0|1).*?m") {
+                if let pattern = try? NSRegularExpression(pattern: "\\033\\[(0|1).*?m") {
                     return pattern.stringByReplacingMatches(in: stringLine, range: NSRange(location: 0, length: stringLine.count), withTemplate: "")
                 }
                 return stringLine

--- a/Source/Worker.swift
+++ b/Source/Worker.swift
@@ -170,10 +170,14 @@ class Worker: ObservableObject {
     }
     
     private nonisolated func extractLine(from data: Data) -> String? {
-        if let string = String(data: data, encoding: .ascii)?.filter({ $0.isASCII }) {
+        if let string = String(data: data, encoding: .utf8) {
             let lines = string.split(whereSeparator: \.isNewline)
             if let line = lines.filter({ !$0.isEmpty }).last {
-                return String(line)
+                let stringLine = String(line)
+                if let pattern = try? NSRegularExpression(pattern: "\\[(0|1).*?m") {
+                    return pattern.stringByReplacingMatches(in: stringLine, range: NSRange(location: 0, length: stringLine.count), withTemplate: "")
+                }
+                return stringLine
             }
         }
         return nil


### PR DESCRIPTION
Fixes #9

Proof it works:
```
Original: [1mUUP Converter v0.7.2[0m / replaced: UUP Converter v0.7.2
Original: Use the Windows version of the converter to integrate updates. / replaced: Use the Windows version of the converter to integrate updates.
Original: [1;94mCAB -> ESD:[0m Microsoft-Windows-MediaPlayer-Package-arm64 / replaced: CAB -> ESD: Microsoft-Windows-MediaPlayer-Package-arm64
Original: [1;94mCAB -> ESD:[0m Microsoft-Windows-LanguageFeatures-OCR-fr-fr-Package-arm64 / replaced: CAB -> ESD: Microsoft-Windows-LanguageFeatures-OCR-fr-fr-Package-arm64
Original: [1;94mCAB -> ESD:[0m Microsoft-Windows-LanguageFeatures-Handwriting-fr-fr-Package-arm64 / replaced: CAB -> ESD: Microsoft-Windows-LanguageFeatures-Handwriting-fr-fr-Package-arm64
Original: [1;94mCAB -> ESD:[0m Microsoft-Windows-PowerShell-ISE-FOD-Package-arm64 / replaced: CAB -> ESD: Microsoft-Windows-PowerShell-ISE-FOD-Package-arm64
Original: [1;94mCAB -> ESD:[0m Microsoft-Windows-Printing-PMCPPC-FoD-Package-arm64 / replaced: CAB -> ESD: Microsoft-Windows-Printing-PMCPPC-FoD-Package-arm64
Original: [1;94mCAB -> ESD:[0m Microsoft-Windows-Notepad-System-FoD-Package-arm64 / replaced: CAB -> ESD: Microsoft-Windows-Notepad-System-FoD-Package-arm64
Original: [1;94mCAB -> ESD:[0m Microsoft-OneCore-ApplicationModel-Sync-Desktop-FOD-Package-arm64 / replaced: CAB -> ESD: Microsoft-OneCore-ApplicationModel-Sync-Desktop-FOD-Package-arm64
Original: [1;94mCAB -> ESD:[0m Microsoft-Windows-QuickAssist-Package-arm64 / replaced: CAB -> ESD: Microsoft-Windows-QuickAssist-Package-arm64
Original: [1;94mCAB -> ESD:[0m Microsoft-Windows-LanguageFeatures-TextToSpeech-fr-fr-Package-arm64 / replaced: CAB -> ESD: Microsoft-Windows-LanguageFeatures-TextToSpeech-fr-fr-Package-arm64
Original: [1;94mCAB -> ESD:[0m Microsoft-Windows-Hello-Face-Package-arm64 / replaced: CAB -> ESD: Microsoft-Windows-Hello-Face-Package-arm64
Original: [1;94mCAB -> ESD:[0m Microsoft-Windows-LanguageFeatures-Speech-fr-fr-Package-arm64 / replaced: CAB -> ESD: Microsoft-Windows-LanguageFeatures-Speech-fr-fr-Package-arm64
Original: [1;94mCAB -> ESD:[0m Microsoft-Windows-WordPad-FoD-Package-arm64 / replaced: CAB -> ESD: Microsoft-Windows-WordPad-FoD-Package-arm64
Original: [1;94mCAB -> ESD:[0m Microsoft-Windows-LanguageFeatures-Basic-fr-fr-Package-arm64 / replaced: CAB -> ESD: Microsoft-Windows-LanguageFeatures-Basic-fr-fr-Package-arm64
Original: [1;94mCAB -> ESD:[0m Microsoft-Windows-InternetExplorer-Optional-Package-arm64 / replaced: CAB -> ESD: Microsoft-Windows-InternetExplorer-Optional-Package-arm64
Original: [1;94mCAB -> ESD:[0m Microsoft-Windows-StepsRecorder-Package-arm64_4c7284f0 / replaced: CAB -> ESD: Microsoft-Windows-StepsRecorder-Package-arm64_4c7284f0
Original: [1;94mCAB -> ESD:[0m OpenSSH-Client-Package-arm64 / replaced: CAB -> ESD: OpenSSH-Client-Package-arm64
Original: [1;94mCAB -> ESD:[0m Microsoft-Windows-TabletPCMath-Package-arm64 / replaced: CAB -> ESD: Microsoft-Windows-TabletPCMath-Package-arm64
Original: [1;94mCAB -> ESD:[0m Microsoft-Windows-UserExperience-Desktop-Package-arm64 / replaced: CAB -> ESD: Microsoft-Windows-UserExperience-Desktop-Package-arm64
Original: [1;94mCreating ISO structure...[0m / replaced: Creating ISO structure...
```