### PR TITLE
feat: Allow UUP Dump JSON API Url to be configured

### DIFF
--- a/CrystalFetch.xcodeproj/project.pbxproj
+++ b/CrystalFetch.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		63E2EBFA2AD1658800A32758 /* GeneralSettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 63E2EBF72AD1651700A32758 /* GeneralSettingsView.swift */; };
 		844A8EFB2A860F91009A389C /* ESDCatalog.swift in Sources */ = {isa = PBXBuildFile; fileRef = 844A8EFA2A860F91009A389C /* ESDCatalog.swift */; };
 		844A8EFF2A86CA8C009A389C /* SimpleContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 844A8EFE2A86CA8C009A389C /* SimpleContentView.swift */; };
 		844A8F032A86E86F009A389C /* EULAView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 844A8F022A86E86F009A389C /* EULAView.swift */; };
@@ -494,6 +495,7 @@
 /* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
+		63E2EBF72AD1651700A32758 /* GeneralSettingsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GeneralSettingsView.swift; sourceTree = "<group>"; };
 		844A8EFA2A860F91009A389C /* ESDCatalog.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ESDCatalog.swift; sourceTree = "<group>"; };
 		844A8EFE2A86CA8C009A389C /* SimpleContentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SimpleContentView.swift; sourceTree = "<group>"; };
 		844A8F022A86E86F009A389C /* EULAView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EULAView.swift; sourceTree = "<group>"; };
@@ -976,6 +978,7 @@
 				CEC09F3E2A6F151800980857 /* CrystalFetch-Info.plist */,
 				FFB1B5282A929CEC00B95D56 /* CrystalFetch-InfoPlist.strings */,
 				CEC8BC522A7B55D80042878F /* Localizable.strings */,
+				63E2EBF72AD1651700A32758 /* GeneralSettingsView.swift */,
 			);
 			path = Source;
 			sourceTree = "<group>";
@@ -1595,6 +1598,7 @@
 				CEC09F372A6E5B7600980857 /* BuildDetails.swift in Sources */,
 				CEC09F3B2A6E629F00980857 /* PrettyString.swift in Sources */,
 				CEC09F3D2A6EECC700980857 /* Downloader.swift in Sources */,
+				63E2EBFA2AD1658800A32758 /* GeneralSettingsView.swift in Sources */,
 				CEC09F2D2A6DC60500980857 /* UUPDetails.swift in Sources */,
 				CEC09F352A6DF33C00980857 /* BuildsListView.swift in Sources */,
 				84EB35722A870EA7004F252E /* ShowWindowButtonView.swift in Sources */,

--- a/Source/GeneralSettingsView.swift
+++ b/Source/GeneralSettingsView.swift
@@ -1,0 +1,40 @@
+//
+// Copyright © 2023 Turing Software, LLC. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+import SwiftUI
+
+let defaultUUPDumpJsonApiUrl = "https://uupdump.net/json-api/"
+
+struct GeneralSettingsView: View {
+    @AppStorage("uupDumpJsonApiUrl") private var uupDumpJsonApiUrl = defaultUUPDumpJsonApiUrl
+
+    var body: some View {
+        Form {
+            TextField("UUP Dump JSON API URL", text: Binding(
+                get: { uupDumpJsonApiUrl },
+                set: { uupDumpJsonApiUrl = $0.isBlank ? defaultUUPDumpJsonApiUrl : $0 })
+            ).autocorrectionDisabled()
+        }
+        .padding(20)
+        .frame(width: 500, height: 100)
+    }
+}
+
+extension String {
+  var isBlank: Bool {
+    return allSatisfy({ $0.isWhitespace })
+  }
+}

--- a/Source/Main.swift
+++ b/Source/Main.swift
@@ -32,5 +32,9 @@ struct Main: App {
         }.commands {
             SidebarCommands()
         }.handlesExternalEvents(matching: Set(["UUPDump"]))
+        
+        Settings {
+            GeneralSettingsView()
+        }
     }
 }


### PR DESCRIPTION
As noted in #27 uupdump.net has been down for many weeks. It may not come back. To allow more savvy/enthusiastic folks to use CrystalFetch with an alternate site, or a local instance - this change makes the UUP Dump URL user-configurable via `Settings...`

![image](https://github.com/TuringSoftware/CrystalFetch/assets/29788154/c5643960-028a-457d-bc61-7b45d3c08aa6)

![image](https://github.com/TuringSoftware/CrystalFetch/assets/29788154/557f2840-7556-4ddd-a7aa-74ab085e9ecc)

![image](https://github.com/TuringSoftware/CrystalFetch/assets/29788154/310df82e-71e2-4451-b146-e8f2650d535e)

I'm not a SwiftUI expert, so not sure of the best way to validate the URL on input and such, but this PR
- Improves reporting of errors if there are errors during requests to include the base server called.
  ![image](https://github.com/TuringSoftware/CrystalFetch/assets/29788154/f1916e4f-0142-4f91-a63b-d17bf112828c)
- logs response parsing errors to NSLog to assist with debugging
- Validated against a local install of UUP Dump per https://github.com/TuringSoftware/CrystalFetch/issues/27#issuecomment-1750303095